### PR TITLE
Add the "logo" command in the help menu

### DIFF
--- a/src/functions/help.asm
+++ b/src/functions/help.asm
@@ -2,7 +2,7 @@
 
 section .data
   msg_help_1: db `-- Functions --\r\n\0`
-  msg_help_2: db ` help - Shows all functions.\r\n about - Shows information about the project.\r\n clear - Clears the screen.\r\n echo - Echoes what you say.\r\n credits - Shows the credits.\r\n user - Sets your username for this session.\r\n gui - Starts the experimental GUI interface\r\n\n\0`
+  msg_help_2: db ` help - Shows all functions.\r\n about - Shows information about the project.\r\n clear - Clears the screen.\r\n echo - Echoes what you say.\r\n credits - Shows the credits.\r\n user - Sets your username for this session.\r\n gui - Starts the experimental GUI interface\r\n logo - Shows the iDOS logo.\r\n\n\0`
 
   cmd_help: db `help\0`
   cmd_help_alias: db `?\0`


### PR DESCRIPTION
Inside `src/kernel.asm`, there is a command called `logo`. This command is registered yet is not in the help menu. This PR adds the command to the help menu.